### PR TITLE
update node-hid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-blink",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "blink(1) support for node",
   "main": "index.js",
   "scripts": {
@@ -8,6 +8,6 @@
   },
   "license": "BSD",
   "dependencies": {
-    "node-hid": "~0.1.1"
+    "node-hid": "~0.4.0"
   }
 }


### PR DESCRIPTION
I think node-blink needs an updated depenency on `node-hid` https://github.com/node-hid/node-hid/issues/75

I cant install the current version.

Today is literally my first day with node - I don't know how to start out really .. can I just 'require 'node-blink'`and call 'blink(...)' after installing`node-blink`?
